### PR TITLE
US474035 Changed adapter type to RestFileSystem

### DIFF
--- a/restadapter-filesystem-core/src/main/java/io/github/fileanalysissuite/restadapters/filesystem/core/FileSystemAdapter.java
+++ b/restadapter-filesystem-core/src/main/java/io/github/fileanalysissuite/restadapters/filesystem/core/FileSystemAdapter.java
@@ -72,7 +72,7 @@ public final class FileSystemAdapter implements RepositoryAdapter
     @Override
     public AdapterDescriptor createDescriptor()
     {
-        return ConvenientAdapterDescriptor.create("RestFileSystemAdapter");
+        return ConvenientAdapterDescriptor.create("RestFileSystem");
     }
 
     @Override


### PR DESCRIPTION
There's a limitation in the UI (and potentially in db) to 20 characters for the adapter type name.