### PR TITLE
US601024: Bring Java Adapter SDK back into sync with .NET version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,17 +351,17 @@
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.convenience</groupId>
                 <artifactId>adaptersdk-convenience</artifactId>
-                <version>1.0.0-US456084FileSize-SNAPSHOT</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.impls.jaxrs</groupId>
                 <artifactId>adaptersdk-impl-jaxrs</artifactId>
-                <version>1.0.0-US456084FileSize-SNAPSHOT</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.interfaces</groupId>
                 <artifactId>adaptersdk-interfaces</artifactId>
-                <version>1.0.0-US456084FileSize-SNAPSHOT</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.github.fileanalysissuite.restadapters.filesystem</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -351,17 +351,17 @@
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.convenience</groupId>
                 <artifactId>adaptersdk-convenience</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-US456084FileSize-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.impls.jaxrs</groupId>
                 <artifactId>adaptersdk-impl-jaxrs</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-US456084FileSize-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.interfaces</groupId>
                 <artifactId>adaptersdk-interfaces</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-US456084FileSize-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.github.fileanalysissuite.restadapters.filesystem</groupId>

--- a/restadapter-filesystem-core/src/main/java/io/github/fileanalysissuite/restadapters/filesystem/core/FileSystemAdapter.java
+++ b/restadapter-filesystem-core/src/main/java/io/github/fileanalysissuite/restadapters/filesystem/core/FileSystemAdapter.java
@@ -108,11 +108,12 @@ public final class FileSystemAdapter implements RepositoryAdapter
             if (subpathAttributes.isDirectory()) {
                 queueAllFiles(pathString, subpath, handler, cancellationToken);
             } else {
-                final FileMetadata fileMetadata = ConvenientFileMetadata.create(
-                    subpath.toString(),
-                    subpath.getFileName().toString(),
-                    subpathAttributes.size(),
-                    subpathAttributes.lastModifiedTime().toInstant());
+                final FileMetadata fileMetadata = ConvenientFileMetadata.builder()
+                                                        .fileLocation(subpath.toString())
+                                                        .name(subpath.getFileName().toString())
+                                                        .size(subpathAttributes.size())
+                                                        .modifiedTime(subpathAttributes.lastModifiedTime().toInstant())
+                                                        .build();
 
                 handler.queueFile(fileMetadata, parentGroupId, cancellationToken);
             }

--- a/restadapter-filesystem-core/src/main/java/io/github/fileanalysissuite/restadapters/filesystem/core/FileSystemAdapter.java
+++ b/restadapter-filesystem-core/src/main/java/io/github/fileanalysissuite/restadapters/filesystem/core/FileSystemAdapter.java
@@ -28,7 +28,7 @@ import io.github.fileanalysissuite.adaptersdk.interfaces.framework.FileListResul
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.OptionsProvider;
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryFile;
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RetrieveFileListRequest;
-import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RetrieveFilesDataRequest;
+import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryFilesRequest;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -121,7 +121,7 @@ public final class FileSystemAdapter implements RepositoryAdapter
 
     @Override
     public void retrieveFilesData(
-        final RetrieveFilesDataRequest request,
+        final RepositoryFilesRequest request,
         final FileDataResultsHandler handler,
         final CancellationToken cancellationToken
     )


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=601024

Renamed RetrieveFilesDataRequest to RepositoryFilesRequest, to be in sync with the changes in .NET Adapter SDK code.

NOTE: This PR must not be merged until https://github.com/FileAnalysisSuite/adaptersdk-interfaces/pull/5 is merged.