### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/restadapter-filesystem-core/pom.xml
+++ b/restadapter-filesystem-core/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>restadapter-filesystem-core</artifactId>
+    <name>restadapter-filesystem-core</name>
 
     <dependencies>
         <dependency>

--- a/restadapter-filesystem-dropwizard-image/pom.xml
+++ b/restadapter-filesystem-dropwizard-image/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>restadapter-filesystem-dropwizard-image</artifactId>
+    <name>restadapter-filesystem-dropwizard-image</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/restadapter-filesystem-dropwizard/pom.xml
+++ b/restadapter-filesystem-dropwizard/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>restadapter-filesystem-dropwizard</artifactId>
+    <name>restadapter-filesystem-dropwizard</name>
 
     <properties>
         <debug.argument>-showversion</debug.argument>

--- a/restadapter-filesystem-tomcat-image/pom.xml
+++ b/restadapter-filesystem-tomcat-image/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>restadapter-filesystem-tomcat-image</artifactId>
+    <name>restadapter-filesystem-tomcat-image</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/restadapter-filesystem-war/pom.xml
+++ b/restadapter-filesystem-war/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>restadapter-filesystem-war</artifactId>
+    <name>restadapter-filesystem-war</name>
     <packaging>war</packaging>
 
     <dependencies>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210